### PR TITLE
Raise BraviaTVTurnedOff when `not power-on`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ __pycache__
 .mypy_cache/
 .tox/
 .venv/
+venv/
 .coverage
 dist/
 docs/_build/

--- a/pybravia/__init__.py
+++ b/pybravia/__init__.py
@@ -8,6 +8,7 @@ from .exceptions import (
     BraviaTVError,
     BraviaTVNotFound,
     BraviaTVNotSupported,
+    BraviaTVTurnedOff,
 )
 
 __version__ = "0.2.2"

--- a/pybravia/client.py
+++ b/pybravia/client.py
@@ -31,6 +31,7 @@ from .exceptions import (
     BraviaTVError,
     BraviaTVNotFound,
     BraviaTVNotSupported,
+    BraviaTVTurnedOff,
 )
 from .util import normalize_cookies
 
@@ -178,6 +179,10 @@ class BraviaTV:
             if response.status == 200:
                 result = await response.json() if json else True
                 _LOGGER.debug("Response result: %s", result)
+                if isinstance(result, dict) and "not power-on" in result.get(
+                    "error", []
+                ):
+                    raise BraviaTVTurnedOff
             if response.status == 404:
                 raise BraviaTVNotFound
             if response.status in [401, 403]:

--- a/pybravia/exceptions.py
+++ b/pybravia/exceptions.py
@@ -23,3 +23,7 @@ class BraviaTVConnectionError(BraviaTVError):
 
 class BraviaTVConnectionTimeout(BraviaTVError):
     """Raised to indicate connection timeout."""
+
+
+class BraviaTVTurnedOff(BraviaTVError):
+    """Raised to indicate TV is turned off and do not respond."""


### PR DESCRIPTION
Related to https://github.com/home-assistant/core/issues/78874

If the TV is turned off and returns `{'error': [7, 'not power-on'], 'id': 1}` we raise `BraviaTVTurnedOff` to be able to mark the device as turned off in HA.