### PR TITLE
Rename BraviaTV to BraviaClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ pip install pybravia
 ### With PSK (recommended)
 
 ```py
-from pybravia import BraviaTV, BraviaTVError
+from pybravia import BraviaClient, BraviaError
 
-async with BraviaTV("192.168.1.20") as client:
+async with BraviaClient("192.168.1.20") as client:
     try:
         connected = await client.connect(psk="sony")
 
@@ -34,7 +34,7 @@ async with BraviaTV("192.168.1.20") as client:
         print(info)
 
         await client.volume_up()
-    except BraviaTVError:
+    except BraviaError:
         print("could not connect")
 ```
 
@@ -43,21 +43,21 @@ async with BraviaTV("192.168.1.20") as client:
 #### Start pairing process and display PIN on the TV
 
 ```py
-from pybravia import BraviaTV
+from pybravia import BraviaClient, BraviaError
 
-async with BraviaTV("192.168.1.20") as client:
+async with BraviaClient("192.168.1.20") as client:
     try:
         await client.pair("CLIENTID", "NICKNAME")
-    except BraviaTVError:
+    except BraviaError:
         print("could not connect")
 ```
 
 #### Connect and usage
 
 ```py
-from pybravia import BraviaTV
+from pybravia import BraviaClient, BraviaError
 
-async with BraviaTV("192.168.1.20") as client:
+async with BraviaClient("192.168.1.20") as client:
     try:
         connected = await client.connect("PIN", "CLIENTID", "NICKNAME")
 
@@ -66,7 +66,7 @@ async with BraviaTV("192.168.1.20") as client:
         print(info)
 
         await client.volume_up()
-    except BraviaTVError:
+    except BraviaError:
         print("could not connect")
 ```
 

--- a/pybravia/__init__.py
+++ b/pybravia/__init__.py
@@ -1,14 +1,14 @@
 """Python library for remote control of Sony Bravia TV."""
 # flake8: noqa
-from .client import BraviaTV
+from .client import BraviaClient
 from .exceptions import (
-    BraviaTVAuthError,
-    BraviaTVConnectionError,
-    BraviaTVConnectionTimeout,
-    BraviaTVError,
-    BraviaTVNotFound,
-    BraviaTVNotSupported,
-    BraviaTVTurnedOff,
+    BraviaAuthError,
+    BraviaConnectionError,
+    BraviaConnectionTimeout,
+    BraviaError,
+    BraviaNotFound,
+    BraviaNotSupported,
+    BraviaTurnedOff,
 )
 
 __version__ = "0.2.5"

--- a/pybravia/const.py
+++ b/pybravia/const.py
@@ -1,4 +1,4 @@
-"""BraviaTV constants."""
+"""Bravia constants."""
 from __future__ import annotations
 
 from typing import Final

--- a/pybravia/exceptions.py
+++ b/pybravia/exceptions.py
@@ -1,29 +1,29 @@
-"""BraviaTV exceptions."""
+"""Bravia exceptions."""
 
 
-class BraviaTVError(Exception):
-    """Base BraviaTV exception."""
+class BraviaError(Exception):
+    """Base Bravia exception."""
 
 
-class BraviaTVAuthError(BraviaTVError):
+class BraviaAuthError(BraviaError):
     """Raised to indicate auth error."""
 
 
-class BraviaTVNotFound(BraviaTVError):
+class BraviaNotFound(BraviaError):
     """Raised to indicate not found error."""
 
 
-class BraviaTVNotSupported(BraviaTVError):
+class BraviaNotSupported(BraviaError):
     """Raised to indicate not supported error."""
 
 
-class BraviaTVConnectionError(BraviaTVError):
+class BraviaConnectionError(BraviaError):
     """Raised to indicate connection error."""
 
 
-class BraviaTVConnectionTimeout(BraviaTVError):
+class BraviaConnectionTimeout(BraviaError):
     """Raised to indicate connection timeout."""
 
 
-class BraviaTVTurnedOff(BraviaTVError):
-    """Raised to indicate TV is turned off and do not respond."""
+class BraviaTurnedOff(BraviaError):
+    """Raised to indicate that TV is turned off and do not respond."""

--- a/pybravia/util.py
+++ b/pybravia/util.py
@@ -1,4 +1,4 @@
-"""BraviaTV utils and helpers."""
+"""Utils and helpers."""
 from __future__ import annotations
 
 import re


### PR DESCRIPTION
## Breaking change

- `BraviaTV` client class renamed to `BraviaClient`
- `BraviaTVError` exception class renamed to `BraviaError`
- `BraviaTVAuthError` exception class renamed to `BraviaAuthError`
- `BraviaTVNotFound` exception class renamed to `BraviaNotFound`
- `BraviaTVNotSupported` exception class renamed to `BraviaNotSupported`
- `BraviaTVConnectionError` exception class renamed to `BraviaConnectionError`
- `BraviaTVConnectionTimeout` exception class renamed to `BraviaConnectionTimeout`
- `BraviaTVTurnedOff` exception class renamed to `BraviaTurnedOff`