### PR TITLE
Fix PIN example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ async def main():
     """Example of connect with PIN."""
     async with BraviaClient(HOST) as client:
         try:
-            connected = await client.connect(PIN, CLIENTID, NICKNAME)
+            connected = await client.connect(pin=PIN, clientid=CLIENTID, nickname=NICKNAME)
             info = await client.get_system_info()
 
             print(info)


### PR DESCRIPTION
Before this change, the second parameter was meant to be `clientid` but was incorrectly passed as `psk`, and similarly for the third parameter.