### PR TITLE
Fix storing normalized cookie with aiohttp 3.10

### DIFF
--- a/pybravia/client.py
+++ b/pybravia/client.py
@@ -177,7 +177,7 @@ class BraviaClient:
             cookies = response.headers.getall("set-cookie", None)
             if cookies:
                 normalized_cookies = normalize_cookies(cookies)
-                self._session.cookie_jar.update_cookies(normalized_cookies)
+                self._session.cookie_jar.update_cookies(cookies=normalized_cookies, response_url=response.url)
 
             if response.status == 200:
                 result = await response.json() if json else True

--- a/pybravia/client.py
+++ b/pybravia/client.py
@@ -177,7 +177,9 @@ class BraviaClient:
             cookies = response.headers.getall("set-cookie", None)
             if cookies:
                 normalized_cookies = normalize_cookies(cookies)
-                self._session.cookie_jar.update_cookies(cookies=normalized_cookies, response_url=response.url)
+                self._session.cookie_jar.update_cookies(
+                    cookies=normalized_cookies, response_url=response.url
+                )
 
             if response.status == 200:
                 result = await response.json() if json else True


### PR DESCRIPTION
aiohttp 3.10 and more specifically https://github.com/aio-libs/aiohttp/pull/7944 changed the way cookies are handled. Previously, the domain did not have to be part of the cookie jar for a cookie to be used. As this was changed in 3.10, we now need to pass in the response URL when updating the cookie jar, otherwise the domain will not be part of the stored cookie, and consequently will not be used for the next request.

Needed for fixing https://github.com/home-assistant/core/issues/123310.