### PR TITLE
Suppress already off error in `turn_off`

### DIFF
--- a/pybravia/client.py
+++ b/pybravia/client.py
@@ -592,7 +592,9 @@ class BraviaClient:
 
     async def turn_off(self) -> bool:
         """Turn off the device."""
-        return await self.set_power_status(False)
+        with suppress(BraviaTurnedOff):
+            return await self.set_power_status(False)
+        return True
 
     async def volume_up(self, step: int = 1, **kwargs: str) -> bool:
         """Increase the volume."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -527,11 +527,20 @@ async def test_turn_off(client: BraviaClient, mock_aioresponse: aioresponses) ->
         f"http://{TEST_HOST}/sony/{SERVICE_SYSTEM}",
         payload={"result": [], "id": 1},
     )
+    mock_aioresponse.post(
+        f"http://{TEST_HOST}/sony/{SERVICE_SYSTEM}",
+        payload={"error": [400, "not power-on"], "id": 1},
+    )
 
     result = await client.turn_off()
+    already_off_result = await client.turn_off()
 
     assert result is True
+    assert already_off_result is True
 
-    kwargs = list(mock_aioresponse.requests.values())[0][0].kwargs
+    requests = list(mock_aioresponse.requests.values())[0]
+    assert len(requests) == 2
+
+    kwargs = requests[0].kwargs
     assert kwargs["json"]["method"] == "setPowerStatus"
     assert kwargs["json"]["params"] == [{"status": False}]


### PR DESCRIPTION
After https://github.com/home-assistant/core/pull/167364, HA started logging an error when attempting to turn off a TV that was already off:

```
Error sending command to KE-55XH9096: the TV is turned off
```

This PR fixes that.