### PR TITLE
Fix `turn_off` lint test

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -538,7 +538,7 @@ async def test_turn_off(client: BraviaClient, mock_aioresponse: aioresponses) ->
     assert result is True
     assert already_off_result is True
 
-    requests = list(mock_aioresponse.requests.values())[0]
+    requests = next(iter(mock_aioresponse.requests.values()))
     assert len(requests) == 2
 
     kwargs = requests[0].kwargs


### PR DESCRIPTION
Fix: Prefer `next(iter(mock_aioresponse.requests.values()))` over single element slice